### PR TITLE
src: remove unecessary get_async_id call

### DIFF
--- a/src/node_quic.cc
+++ b/src/node_quic.cc
@@ -36,8 +36,7 @@ void QuicSocket::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsObject());
   Local<Object> options = args[0].As<Object>();
   QuicSocketConfig config(options);
-  QuicSocket* socket = new QuicSocket(env, args.This(), config, nullptr);
-  socket->get_async_id();  // avoid compiler warning
+  new QuicSocket(env, args.This(), config, nullptr);
 }
 
 namespace {


### PR DESCRIPTION
This commit removes the call to get_async_id as the comment suggests
that this is only done so that the compiler will not complain about an
unused variable. Just calling new QuickStocket should be enough and is
what other classes do (for example TCPWrap).


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
