### PR TITLE
src: cast addrlen/remotelen to socklen_t

### DIFF
--- a/src/node_quic.cc
+++ b/src/node_quic.cc
@@ -815,12 +815,12 @@ int QuicServerSession::Init(const struct sockaddr* addr,
   auto path = ngtcp2_path{
       // Local Address
       {
-        addrlen,
+        static_cast<socklen_t>(addrlen),
         const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(&local_addr))
       },
       // Remote Address
       {
-        remote_len,
+        static_cast<socklen_t>(remote_len),
         const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(addr))
       }
     };


### PR DESCRIPTION
Currently, I'm seeing the following compilation error:
```console
../src/node_quic.cc:819:9:
error: non-constant-expression cannot be narrowed from type 'int' to
'size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
        addrlen,
        ^~~~~~~
../src/node_quic.cc:819:9:
note: insert an explicit cast to silence this issue
        addrlen,
        ^~~~~~~
        static_cast<size_t>( )
```
This commit adds a cast to type `socklen_t`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
